### PR TITLE
'Normal' usage 'animation lag' fix

### DIFF
--- a/js/skillsTools.js
+++ b/js/skillsTools.js
@@ -59,8 +59,9 @@
     $("#tool-header").click(function () {
         let toolCatalog = $("#tool-catalog");
         if (toolCatalog.css("display") === "none") {
-            // animateTools();
-            animationToolFunc();
+            setTimeout(function () { // accounts for expansion load time to avoid "animation lag" on first tool-item
+                animationToolFunc();
+            },400); // timeout equals collapseExpand().duration
         } else {
             clearInterval(toolAnimationID);
         }


### PR DESCRIPTION
added a 'delay' to the animationToolFunc() when toolHeader click is expanding to prevent the animation lag that would be visible without this implementation. Note: 'animation lag' may still appear after repeatedly clicking the toolHeader. This is only a 'normal usage' fix